### PR TITLE
dlwrap: add GLIBC_2.4 version to be able to run tests from ARM

### DIFF
--- a/test/dlwrap.c
+++ b/test/dlwrap.c
@@ -232,6 +232,7 @@ dlwrap_real_dlsym(void *handle, const char *name)
          * In the meantime, I'll just keep augmenting this
          * hard-coded version list as people report bugs. */
         const char *version[] = {
+            "GLIBC_2.4",
             "GLIBC_2.2.5",
             "GLIBC_2.0"
         };


### PR DESCRIPTION
See sysdeps/unix/sysv/linux/arm/libdl.abilist in glibc
